### PR TITLE
Add microdata markup to detail pages

### DIFF
--- a/app/controllers/location_controller.rb
+++ b/app/controllers/location_controller.rb
@@ -178,7 +178,7 @@ class LocationController < ApplicationController
   end
 
   def fetch(slug)
-    FT.execute("SELECT * FROM #{APP_CONFIG['fusion_table_id']} WHERE slug = '#{slug}';").first
+    Location.new(FT.execute("SELECT * FROM #{APP_CONFIG['fusion_table_id']} WHERE slug = '#{slug}';").first)
   end
 
   def fetch_row_id(slug)

--- a/app/controllers/location_controller.rb
+++ b/app/controllers/location_controller.rb
@@ -6,7 +6,7 @@ class LocationController < ApplicationController
   caches_action :index, :layout => false
 
   def index
-    @locations = FT.execute("SELECT * FROM #{APP_CONFIG['fusion_table_id']} ORDER BY organization_name;") || not_found
+    @locations = Location.all
   end
 
   def show
@@ -137,23 +137,22 @@ class LocationController < ApplicationController
       expire_action :action => :index
 
       begin
-        location_edit = fetch params[:id]
-        @location = Location.new(location_edit)
+        @location = fetch params[:id]
         # save to location_changes tracking table
         save_location_changes({"Location deleted" => ""})
 
         table = fetch_table
-        row_id = fetch_row_id location_edit[:slug]
+        row_id = fetch_row_id @location.slug
         table.delete row_id
         flash[:notice] = "Location deleted successfully!"
-        redirect_to "/"
+        redirect_to root_path
       rescue
         flash[:notice] = "There was a problem deleting this location. Please try again or contact the system administrator."
-        redirect_to "/location/#{location_edit[:slug]}"
+        redirect_to location_path :id => @location.slug
       end
     else
       flash[:notice] = "You must be a super admin to delete locations."
-      redirect_to "/location/#{location_edit[:slug]}"
+      redirect_to location_path :id => @location.slug
     end
   end
 

--- a/app/controllers/location_controller.rb
+++ b/app/controllers/location_controller.rb
@@ -1,7 +1,8 @@
 class LocationController < ApplicationController
   before_filter :authenticate_admin!, :except => [:index, :show, :showImage, :showWidget]
+  before_filter :set_location, :only => [:show]
   # caches_action :showImage
-  # caches_action :show, :layout => false
+  caches_action :show, :layout => false
   caches_action :index, :layout => false
 
   def index
@@ -9,19 +10,16 @@ class LocationController < ApplicationController
   end
 
   def show
-    @location = fetch(params[:id]) || not_found
-    
     respond_to do |format|
       format.html  # show.html.haml
       format.json  { render :json => @location }
     end
-
   end
 
   def showImage
     require 'open-uri'
     location = fetch params[:id]
-    featured_photo = getFlickrFeaturedPhoto(location[:flickr_tag])
+    featured_photo = getFlickrFeaturedPhoto(location.flickr_tag)
     unless featured_photo.nil?
       url = URI.parse(getFlickrPhotoPath(featured_photo, params[:size]))
       open(url) do |http|
@@ -183,6 +181,11 @@ class LocationController < ApplicationController
 
   def fetch_row_id(slug)
     FT.execute("SELECT ROWID FROM #{APP_CONFIG['fusion_table_id']} WHERE slug = '#{slug}';").first[:rowid]
+  end
+
+  def set_location
+    @location = fetch(params[:id]) || not_found
+    @page_title = @location.organization_name
   end
 
   def set_changes(location_edit, params)

--- a/app/controllers/location_controller.rb
+++ b/app/controllers/location_controller.rb
@@ -1,7 +1,7 @@
 class LocationController < ApplicationController
   before_filter :authenticate_admin!, :except => [:index, :show, :showImage, :showWidget]
   # caches_action :showImage
-  caches_action :show, :layout => false
+  # caches_action :show, :layout => false
   caches_action :index, :layout => false
 
   def index

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -36,7 +36,7 @@ module ApplicationHelper
   end
   
   def formatAddress street, city, state, zip, room
-    result = "<span itemprop='location' itemscope itemtype='http://schema.org/PostalAddress'>"    
+    result = "<span itemprop='address' itemscope itemtype='http://schema.org/PostalAddress'>"    
     result += "<span itemprop='streetAddress'>#{street}</span>"
     result += "<br />"
     result += "<span itemprop='addressLocality'>#{city}</span>, <span itemprop='addressRegion'>#{state}</span> <span itemprop='postalCode'>#{zip}</span>"

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -36,21 +36,28 @@ module ApplicationHelper
   end
   
   def formatAddress street, city, state, zip, room
-    result = street
+    result = "<span itemprop='location' itemscope itemtype='http://schema.org/PostalAddress'>"    
+    result += "<span itemprop='streetAddress'>#{street}</span>"
     result += "<br />"
-    result += "#{city}, #{state} #{zip}"
+    result += "<span itemprop='addressLocality'>#{city}</span>, <span itemprop='addressRegion'>#{state}</span> <span itemprop='postalCode'>#{zip}</span>"
     unless room.nil?
       result += "<br />"
       result += room
     end
+    result += "</span>"
     result.html_safe()
   end
 
   def formatContact name, email
-    result = name
-    unless (email.nil?)
-      result = "<a href='mailto:#{email}'>#{name}</a>";
+    result = "<span itemprop='contactPoint' itemscope itemtype='http://schema.org/ContactPoint'>"
+    
+    result += if email.blank?
+      "<span itemprop='name'>#{name}</span>"
+    else
+      "<a itemprop='email' href='mailto:#{email}'><span itemprop='name'>#{name}</span></a>";
     end
+    
+    result += "</span>"
     result.html_safe()
   end
   

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -1,13 +1,18 @@
 class Location
   include ActiveModel::Validations
   include ActiveModel::Conversion
+  extend ActiveModel::Callbacks
   extend ActiveModel::Naming
-  
+    
   validates_presence_of :organization_name, :organization_type, :org_phone, :address, :city, :state, :zip_code
   # validates_format_of :agency_staff_person_contact_email, :location_leadership_email, :pcc_staff_person_email, 
   #                     :with => /^[-a-z0-9_+\.]+\@([-a-z0-9]+\.)+[a-z0-9]{2,4}$/i,
   #                     :allow_nil => true, :allow_blank => true
-
+  
+  define_model_callbacks :create, :save
+  after_save    :bust_cache
+  after_create  :bust_cache
+  
   def create_method( name, &block )
     self.class.send( :define_method, name, &block )
   end
@@ -83,4 +88,9 @@ class Location
     end
     collection
   end
+  
+  def bust_cache
+    Rails.cache.delete("all-locations")
+  end
+  
 end

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -28,6 +28,7 @@ class Location
   end
 
   def []=(attr, val)
+    create_attr(attr.to_s) unless respond_to?(attr)  # initialize new attrs on the fly
     self.send("#{attr}=", val)
   end
   
@@ -48,6 +49,13 @@ class Location
       memo[k.to_sym] = send(k)
       memo
     end
+  end
+  
+  def create
+    table = GData::Client::FusionTables::Table.new(FT, :table_id => APP_CONFIG['fusion_table_id'], :name => "My table")
+    column_names = FT.execute("SELECT * FROM #{APP_CONFIG['fusion_table_id']} LIMIT 1;").first.collect{|k,v| k }    
+    new_values = self.to_fusion_format.delete_if{ |k,v| !column_names.include?(k) }    
+    table.insert new_values #saves to Fusion Tables    
   end
   
   def save

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -5,7 +5,7 @@
     %meta(http-equiv="X-UA-Compatible" content="IE=Edge,chrome=1")
     %meta(name="viewport" content="width=device-width, initial-scale=1.0")
     %meta(name="google-site-verification" content="97Jq6z293C73QwTFJHshmEDl_6jI8bXvyRDm70scPmE")
-    %title= content_for?(:title) ? yield(:title) + " - Connect Chicago" : "Connect Chicago"
+    %title= @page_title ? "#{@page_title} - Connect Chicago" : "Connect Chicago"
     = csrf_meta_tags
     / Le HTML5 shim, for IE6-8 support of HTML elements
     /[if lt IE 9]

--- a/app/views/location/show.html.haml
+++ b/app/views/location/show.html.haml
@@ -10,10 +10,10 @@
 
 %script{:src => "/admin/admins/logged_in.js", :type => "text/javascript"}
 %script{:src => "/admin/admins/is_superadmin.js", :type => "text/javascript"}
-.row
+.row{:itemscope => '', :itemtype => "http://schema.org/Organization"}
   .span7
     %h2
-      = @location[:organization_name]
+      %span{:itemprop => "name"}= @location[:organization_name]
       %small.admin-edit{:style => 'display: none;'}
         %a{:href => "/location/#{params[:id]}/edit"} 
           %i.icon-pencil
@@ -40,9 +40,10 @@
         
         %p 
           - unless @location[:org_phone] == ''
-            = number_to_phone((@location[:org_phone].gsub /[^0-9x]/, ''), :area_code => true)
+            %span{:itemprop => "telephone"}= number_to_phone((@location[:org_phone].gsub /[^0-9x]/, ''), :area_code => true)
           - unless @location[:website] == ''
             %br
+            %span{:itemprop => 'url', :style => "display:none;"}= @location[:website]
             %a{:href => @location[:website]}
               = snippet @location[:website]
 
@@ -77,7 +78,7 @@
         - unless @location[:friendly_description] == ''
           %hr
           %h4 About this place
-          %p
+          %p{:itemprop => 'description'}
             = @location[:friendly_description]
         
         - unless @location[:training_headline] == ''

--- a/app/views/location/show.html.haml
+++ b/app/views/location/show.html.haml
@@ -1,11 +1,11 @@
-- title @location[:organization_name]
+- title @location.organization_name
 - page_layout "container"
 :javascript 
   $(function(){
     MapsDetailLib.initializeMap();
   
     if (MapsDetailLib.map != null)
-      MapsDetailLib.displayPoint("#{encodeAddress(@location[:full_address])}");
+      MapsDetailLib.displayPoint("#{encodeAddress(@location.full_address)}");
   });
 
 %script{:src => "/admin/admins/logged_in.js", :type => "text/javascript"}
@@ -13,7 +13,7 @@
 .row{:itemscope => '', :itemtype => "http://schema.org/Place"}
   .span7
     %h2
-      %span{:itemprop => "name"}= @location[:organization_name]
+      %span{:itemprop => "name"}= @location.organization_name
       %small.admin-edit{:style => 'display: none;'}
         %a{:href => "/location/#{params[:id]}/edit"} 
           %i.icon-pencil
@@ -22,7 +22,7 @@
           %i.icon-remove
           Delete
     %p.lead
-      = @location[:organization_type]
+      = @location.organization_type
 
     %p
       / AddThis Button BEGIN
@@ -36,29 +36,29 @@
     .row  
       .span4
         %p  
-          = formatAddress @location[:address], @location[:city], @location[:state], @location[:zip_code], @location[:room_list]
+          = formatAddress @location.address, @location.city, @location.state, @location.zip_code, @location.room_list
           %span{:itemprop => 'geo', :itemscope => '', :itemtype => 'http://schema.org/GeoCoordinates', :style => "display:none"}
-            %span{:itemprop => 'latitude'}= @location[:latitude]
-            %span{:itemprop => 'longitude'}= @location[:longitude]
+            %span{:itemprop => 'latitude'}= @location.latitude
+            %span{:itemprop => 'longitude'}= @location.longitude
           
         %p 
-          - unless @location[:org_phone] == ''
-            %span{:itemprop => "telephone"}= number_to_phone((@location[:org_phone].gsub /[^0-9x]/, ''), :area_code => true)
-          - unless @location[:website] == ''
+          - unless @location.org_phone == ''
+            %span{:itemprop => "telephone"}= number_to_phone((@location.org_phone.gsub /[^0-9x]/, ''), :area_code => true)
+          - unless @location.website == ''
             %br
-            %span{:itemprop => 'url', :style => "display:none;"}= @location[:website]
-            %a{:href => @location[:website]}
-              = snippet @location[:website]
+            %span{:itemprop => 'url', :style => "display:none;"}= @location.website
+            %a{:href => @location.website}
+              = snippet @location.website
 
-          - unless @location[:pcc_staff_person] == ''
+          - unless @location.pcc_staff_person == ''
             %br
               Administrator:  
-              = formatContact @location[:pcc_staff_person], @location[:pcc_staff_person_email]
+              = formatContact @location.pcc_staff_person, @location.pcc_staff_person_email
               
-        - unless @location[:hours] == ''
+        - unless @location.hours == ''
           %p
             Hours:  
-            = @location[:hours]
+            = @location.hours
     
       .span3  
         %table.table.table-bordered
@@ -71,79 +71,79 @@
           %tbody
             %tr
               %td
-                = yes_no_icon @location[:internet]
+                = yes_no_icon @location.internet
               %td
-                = yes_no_icon @location[:training]
+                = yes_no_icon @location.training
               %td
-                = yes_no_icon @location[:wifi]
+                = yes_no_icon @location.wifi
     .row
       .span7
-        - unless @location[:friendly_description] == ''
+        - unless @location.friendly_description == ''
           %hr
           %h4 About this place
           %p{:itemprop => 'description'}
-            = @location[:friendly_description]
+            = @location.friendly_description
         
-        - unless @location[:training_headline] == ''
+        - unless @location.training_headline == ''
           %hr
           %h4 
             Training
           %h5
-            = @location[:training_headline]
+            = @location.training_headline
           %p
-            = @location[:training_description]
+            = @location.training_description
 
-        - unless @location[:hardware_public] == '' 
+        - unless @location.hardware_public == '' 
           %hr
           %h4 
             Additional info
             
           %dl.dl-horizontal
-            - unless @location[:hardware_public] == ''  
+            - unless @location.hardware_public == ''  
               %dt
                 Computers
               %dd
-                = @location[:hardware_public]
+                = @location.hardware_public
                 computers available to the public
                 
-            - unless @location[:internet_upload] == ''
+            - unless @location.internet_upload == ''
               %dt 
                 Internet speed
               %dd
                 Upload: 
-                = @location[:internet_upload] 
+                = @location.internet_upload 
               %dd
                 Download: 
-                = @location[:internet_download] 
+                = @location.internet_download 
               
-            - unless @location[:pc_use_restrictions] == ''
+            - unless @location.pc_use_restrictions == ''
               %dt 
                 Use restrictions
               %dd 
-                = @location[:pc_use_restrictions]
+                = @location.pc_use_restrictions
             
-            - unless @location[:assistive_technology] == ''
+            - unless @location.assistive_technology == ''
               %dt 
                 Assistive tech
               %dd 
-                = @location[:assistive_technology] 
+                = @location.assistive_technology 
             
-            - unless @location[:time_allowed_per_user] == ''
+            - unless @location.time_allowed_per_user == ''
               %dt 
                 Time restrictions
               %dd
-                = @location[:time_allowed_per_user] 
+                = @location.time_allowed_per_user 
               %dd
-                = @location[:time_allowed_per_user_detail]
+                = @location.time_allowed_per_user_detail
                 
     .row.hidden-phone
       .span7
         %hr
         %h4 
           Photos of 
-          = @location[:organization_name]
+          = @location.organization_name
         %ul.thumbnails#gallery{:"data-toggle" => "modal-gallery", :"data-target" => "#modal-gallery"}
-          - getFlickrGalleryPhotos(@location[:flickr_tag]).each do |photo|
+          - getFlickrGalleryPhotos(@location.flickr_tag).each do |photo|
             %li.span1
               %a.thumbnail{:href => getFlickrPhotoPath(photo, 'z'), :rel =>"gallery", :title => "#{photo.title}"}
                 %img{:src => getFlickrPhotoPath(photo, 's')} 
@@ -153,45 +153,45 @@
           %a{:href => "http://flickr.com"} Flickr
           and tag it with
           %strong
-            = @location[:flickr_tag]
+            = @location.flickr_tag
                 
   .span5
     .well
       %p
-        - featured_photo = getFlickrFeaturedPhoto(@location[:flickr_tag])
+        - featured_photo = getFlickrFeaturedPhoto(@location.flickr_tag)
         - unless featured_photo.nil?
-          %img.img-polaroid{:src => "/location/#{params[:id]}/image.jpg", :title => @location[:organization_name], :alt => @location[:organization_name], :itemprop => 'image'}
+          %img.img-polaroid{:src => "/location/#{params[:id]}/image.jpg", :title => @location.organization_name, :alt => @location.organization_name, :itemprop => 'image'}
 
       #mapDetail
       %hr
       %p.lead
-        = formatAddress @location[:address], @location[:city], @location[:state], @location[:zip_code], @location[:roomlist]
+        = formatAddress @location.address, @location.city, @location.state, @location.zip_code, ''
       %p
-        %a.btn.btn-success{:href => "https://maps.google.com/maps?f=d&hl=en&geocode=&daddr=#{encodeAddress(@location[:full_address])}"}
+        %a.btn.btn-success{:href => "https://maps.google.com/maps?f=d&hl=en&geocode=&daddr=#{encodeAddress(@location.full_address)}"}
           Get directions
           %i.icon-white.icon-arrow-right
           
       
       %dl.dl-horizontal
-        - unless @location[:nearest_parking] == ''
+        - unless @location.nearest_parking == ''
           %dt
             Nearest parking 
           %dd
-            = @location[:nearest_parking]
+            = @location.nearest_parking
           %dd
-            = @location[:nearest_parking_detail]
+            = @location.nearest_parking_detail
         
-        - unless @location[:public_transportation_detail] == ''
+        - unless @location.public_transportation_detail == ''
           %dt
             Public transit
           %dd 
-            = @location[:public_transportation_detail]
+            = @location.public_transportation_detail
             
-        - unless @location[:handicap_access_detail] == ''
+        - unless @location.handicap_access_detail == ''
           %dt
             Handicap access
           %dd 
-            = @location[:handicap_access_detail]
+            = @location.handicap_access_detail
 
       %hr
       %h4 Do you help manage this location? 

--- a/app/views/location/show.html.haml
+++ b/app/views/location/show.html.haml
@@ -157,7 +157,7 @@
       %p
         - featured_photo = getFlickrFeaturedPhoto(@location[:flickr_tag])
         - unless featured_photo.nil?
-          %img.img-polaroid{:src => "/location/#{params[:id]}/image.jpg", :title => @location[:organization_name], :alt => @location[:organization_name]}
+          %img.img-polaroid{:src => "/location/#{params[:id]}/image.jpg", :title => @location[:organization_name], :alt => @location[:organization_name], :itemprop => 'image'}
 
       #mapDetail
       %hr

--- a/app/views/location/show.html.haml
+++ b/app/views/location/show.html.haml
@@ -1,4 +1,3 @@
-- title @location.organization_name
 - page_layout "container"
 :javascript 
   $(function(){

--- a/app/views/location/show.html.haml
+++ b/app/views/location/show.html.haml
@@ -37,7 +37,10 @@
       .span4
         %p  
           = formatAddress @location[:address], @location[:city], @location[:state], @location[:zip_code], @location[:room_list]
-        
+          %span{:itemprop => 'geo', :itemscope => '', :itemtype => 'http://schema.org/GeoCoordinates', :style => "display:none"}
+            %span{:itemprop => 'latitude'}= @location[:latitude]
+            %span{:itemprop => 'longitude'}= @location[:longitude]
+          
         %p 
           - unless @location[:org_phone] == ''
             %span{:itemprop => "telephone"}= number_to_phone((@location[:org_phone].gsub /[^0-9x]/, ''), :area_code => true)

--- a/app/views/location/show.html.haml
+++ b/app/views/location/show.html.haml
@@ -10,7 +10,7 @@
 
 %script{:src => "/admin/admins/logged_in.js", :type => "text/javascript"}
 %script{:src => "/admin/admins/is_superadmin.js", :type => "text/javascript"}
-.row{:itemscope => '', :itemtype => "http://schema.org/Organization"}
+.row{:itemscope => '', :itemtype => "http://schema.org/Place"}
   .span7
     %h2
       %span{:itemprop => "name"}= @location[:organization_name]


### PR DESCRIPTION
This change adds microdata to the location detail page.

Microdata is a method to annotate information with semantic "hints". Search engine indexers use these hints to understand the content of pages and, in some cases, alter the display of items in search results.

Spec: http://schema.org/

This change also tweaks a lot of how updates and creations of items works, moving more of that logic to the Location model.
