### PR TITLE
Handle missing location better

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,9 +9,11 @@ class ApplicationController < ActionController::Base
 
   private
   def render_error(status, exception)
-    # send error email on 500s
-    ExceptionNotifier::Notifier.exception_notification(request.env, exception).deliver if status == 500
-    Rails.logger.fatal "[FATAL] #{exception.message}\n\nBacktrace:\n\n#{exception.backtrace.join(%Q(\n))}"
+    if status == 500
+      # send error email on 500s
+      ExceptionNotifier::Notifier.exception_notification(request.env, exception).deliver
+      Rails.logger.fatal "[FATAL] #{exception.message}\n\nBacktrace:\n\n#{exception.backtrace.join(%Q(\n))}"
+    end
 
     respond_to do |format|
       format.html { render template: "errors/error_#{status}", layout: 'layouts/application', status: status }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,7 +9,8 @@ class ApplicationController < ActionController::Base
 
   private
   def render_error(status, exception)
-    ExceptionNotifier::Notifier.exception_notification(request.env, exception).deliver
+    # send error email on 500s
+    ExceptionNotifier::Notifier.exception_notification(request.env, exception).deliver if status == 500
     Rails.logger.fatal "[FATAL] #{exception.message}\n\nBacktrace:\n\n#{exception.backtrace.join(%Q(\n))}"
 
     respond_to do |format|

--- a/app/controllers/location_controller.rb
+++ b/app/controllers/location_controller.rb
@@ -172,7 +172,8 @@ class LocationController < ApplicationController
   end
 
   def fetch(slug)
-    Location.new(FT.execute("SELECT * FROM #{APP_CONFIG['fusion_table_id']} WHERE slug = '#{slug}';").first)
+    location = FT.execute("SELECT * FROM #{APP_CONFIG['fusion_table_id']} WHERE slug = '#{slug}';").first
+    location.present? ? Location.new(location) : nil
   end
 
   def fetch_row_id(slug)

--- a/app/views/location/index.html.haml
+++ b/app/views/location/index.html.haml
@@ -9,7 +9,7 @@
       %br
       = location[:organization_type]
       %br
-      = formatAddress location[:address], location[:city], location[:state], location[:zip_code], location[:roomlist]
+      = formatAddress location[:address], location[:city], location[:state], location[:zip_code], ''
       %br
       - unless location[:hours].nil?
         = location[:hours]

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -45,5 +45,5 @@ TechLocator::Application.configure do
   config.middleware.use ExceptionNotifier,
       :email_prefix => "[Exception] ",
       :sender_address => %{"Exception Notifier" <error@weconnectchicago.org>},
-      :exception_recipients => %w{derek.eder@gmail.com}
+      :exception_recipients => %w{cgansen@gmail.com}
 end

--- a/config/initializers/config.rb
+++ b/config/initializers/config.rb
@@ -20,16 +20,16 @@ rescue Errno::ENOENT
 
 end
 
-#APP_CONFIG['domain'] = 'http://localhost:8888/'
 APP_CONFIG['domain'] = 'http://weconnectchicago.org/'
-
-#puts "google_account: #{APP_CONFIG['google_account']}"
-#puts "google_password: #{APP_CONFIG['google_password']}"
 
 #initialize Fusion Tables API
 FT = GData::Client::FusionTables.new      
-FT.clientlogin(APP_CONFIG['google_account'], APP_CONFIG['google_password'])
-FT.set_api_key(APP_CONFIG['google_api_key'])
+begin
+  FT.clientlogin(APP_CONFIG['google_account'], APP_CONFIG['google_password'])
+  FT.set_api_key(APP_CONFIG['google_api_key'])
+rescue StandardError => e
+  puts "[fusion tables] error initializing Fusion Tables API. Fusion Tables are unavailable. \n[fusion tables] Error message: #{e.message}."
+end
 
 #initialize Flickr
 FlickRaw.api_key=APP_CONFIG['flickr_key']


### PR DESCRIPTION
Cleans up a lot of code regarding 404s, including how we handle non-existent slugs, notifications of exceptions, and the list of all locations, `/location`
