### PR TITLE
adding basic unicorn configuration

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: bundle exec unicorn -p $PORT -c ./config/unicorn.rb

--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -1,0 +1,26 @@
+# copied from https://blog.heroku.com/archives/2013/2/27/unicorn_rails
+# config/unicorn.rb
+worker_processes 3
+timeout 30
+preload_app true
+
+before_fork do |server, worker|
+
+  Signal.trap 'TERM' do
+    puts 'Unicorn master intercepting TERM and sending myself QUIT instead'
+    Process.kill 'QUIT', Process.pid
+  end
+
+  defined?(ActiveRecord::Base) and
+    ActiveRecord::Base.connection.disconnect!
+end
+
+after_fork do |server, worker|
+
+  Signal.trap 'TERM' do
+    puts 'Unicorn worker intercepting TERM and doing nothing. Wait for master to sent QUIT'
+  end
+
+  defined?(ActiveRecord::Base) and
+    ActiveRecord::Base.establish_connection
+end


### PR DESCRIPTION
This switches the application to use unicorn in production, which is a far more performant app server than webrick.

Configuration details shamelessly copied from https://blog.heroku.com/archives/2013/2/27/unicorn_rails
