### PR TITLE
Make location field required for new admin records

### DIFF
--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -8,6 +8,8 @@ class Admin < ActiveRecord::Base
   # Setup accessible (or protected) attributes for your model
   attr_accessible :first_name, :last_name, :organization, :twitter_handle, :email, :password, :password_confirmation, :remember_me, :location_id
   
+  validates_presence_of :location_id
+  
   after_create :send_admin_mail
   def send_admin_mail
      AdminsMailer.signup_notify_admin(self).deliver

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -5,8 +5,7 @@
     = f.input :first_name
     = f.input :last_name
     = f.input :organization, hint:"Your organization or agency"
-    = f.label :location_id, "Associated location<br/>(If your location is not in this list, <a href='http://weconnectchicago.org/contact-us/'>contact us</a>)".html_safe
-    = f.select :location_id, locationNameList
+    = f.input :location_id, collection: locationNameList, member_label: :first, member_value: :last, label: "Associated Location", as: :select, include_blank: false, hint: "(If your location is not in this list, please <a href='http://weconnectchicago.org/contact-us/'>contact us</a>)".html_safe
     = f.input :twitter_handle, hint:"(optional)"
     = f.input :email, hint:"Enter your email address"
     = f.input :password, hint:"Enter password"


### PR DESCRIPTION
This change makes the location field in the admin signup form a required field.

This change closes issue #22.
